### PR TITLE
add prefix to options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json-to-ts",
-  "version": "1.4.4",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -27,8 +27,8 @@
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.7.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "balanced-match": {
@@ -43,7 +43,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -59,7 +59,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "concat-map": {
@@ -82,8 +82,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "diff": {
@@ -97,10 +97,10 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
       "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.0",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.0",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.3"
       }
     },
     "es-to-primitive": {
@@ -108,9 +108,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es7-shim": {
@@ -118,15 +118,15 @@
       "resolved": "https://registry.npmjs.org/es7-shim/-/es7-shim-6.0.0.tgz",
       "integrity": "sha1-DEMLQLhQWtFVcHIajY3U6wxVMVU=",
       "requires": {
-        "array-includes": "3.0.3",
-        "object.entries": "1.0.4",
-        "object.getownpropertydescriptors": "2.0.3",
-        "object.values": "1.0.4",
-        "string-at": "1.0.1",
-        "string.prototype.padend": "3.0.0",
-        "string.prototype.padstart": "3.0.0",
-        "string.prototype.trimleft": "2.0.0",
-        "string.prototype.trimright": "2.0.0"
+        "array-includes": "^3.0.2",
+        "object.entries": "^1.0.3",
+        "object.getownpropertydescriptors": "^2.0.2",
+        "object.values": "^1.0.3",
+        "string-at": "^1.0.1",
+        "string.prototype.padend": "^3.0.0",
+        "string.prototype.padstart": "^3.0.0",
+        "string.prototype.trimleft": "^2.0.0",
+        "string.prototype.trimright": "^2.0.0"
       }
     },
     "escape-string-regexp": {
@@ -157,12 +157,12 @@
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-readlink": {
@@ -182,7 +182,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "^1.0.2"
       }
     },
     "has-flag": {
@@ -196,8 +196,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "inflight": {
@@ -206,8 +206,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -230,7 +230,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-symbol": {
@@ -250,8 +250,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -284,9 +284,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -307,9 +307,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "minimalistic-assert": {
@@ -323,7 +323,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -376,10 +376,10 @@
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.7.0",
-        "function-bind": "1.1.0",
-        "has": "1.0.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -387,8 +387,8 @@
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.7.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.values": {
@@ -396,10 +396,10 @@
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.7.0",
-        "function-bind": "1.1.0",
-        "has": "1.0.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "once": {
@@ -408,7 +408,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -427,9 +427,9 @@
       "resolved": "https://registry.npmjs.org/string-at/-/string-at-1.0.1.tgz",
       "integrity": "sha1-c7dVrbqsPheNq+fk19ed5WAD+zc=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.7.0",
-        "function-bind": "1.1.0"
+        "define-properties": "^1.0.1",
+        "es-abstract": "^1.2.1",
+        "function-bind": "^1.0.2"
       }
     },
     "string.prototype.padend": {
@@ -437,9 +437,9 @@
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
       "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.7.0",
-        "function-bind": "1.1.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
       }
     },
     "string.prototype.padstart": {
@@ -447,9 +447,9 @@
       "resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.0.0.tgz",
       "integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.7.0",
-        "function-bind": "1.1.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
       }
     },
     "string.prototype.trimleft": {
@@ -457,8 +457,8 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
       "integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.0"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.0.2"
       }
     },
     "string.prototype.trimright": {
@@ -466,8 +466,8 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
       "integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.0"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.0.2"
       }
     },
     "supports-color": {
@@ -476,7 +476,7 @@
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "^1.0.0"
       }
     },
     "wrappy": {

--- a/src/get-names.ts
+++ b/src/get-names.ts
@@ -6,6 +6,7 @@ import { getTypeDescriptionGroup, parseKeyMetaData, findTypeById, isHash } from 
 function getName(
   { rootTypeId, types }: TypeStructure,
   keyName: string,
+  prefix: string,
   names: NameEntry[],
   isInsideArray: boolean,
 ): NameStructure {
@@ -20,6 +21,7 @@ function getName(
             { rootTypeId: typeIdOrPrimitive, types },
             // to differenttiate array types
             i === 0 ? keyName : `${keyName}${i + 1}`,
+            prefix,
             names,
             true
           )
@@ -31,10 +33,11 @@ function getName(
 
     case TypeGroup.Object:
       Object.entries(typeDesc.typeObj)
-        .forEach( ([key, value]) => {
+        .forEach(([key, value]) => {
           getName(
             { rootTypeId: value, types },
             key,
+            prefix,
             names,
             false
           )
@@ -53,11 +56,11 @@ function getName(
   }
 }
 
-export function getNames(typeStructure: TypeStructure, rootName: string = 'RootObject'): NameEntry[] {
-  return getName(typeStructure, rootName, [], false).names.reverse()
+export function getNames(typeStructure: TypeStructure, rootName: string = 'RootObject', prefix?: string): NameEntry[] {
+  return getName(typeStructure, rootName, prefix, [], false).names.reverse()
 }
 
-function getNameById (
+function getNameById(
   id: string,
   keyName: string,
   isInsideArray: boolean,
@@ -92,17 +95,17 @@ function getNameById (
         .map(pascalCase)
         .map(normalizeInvalidTypeName)
         .map(pascalCase) // needed because removed symbols might leave first character uncapitalized
-        .map(name => uniqueByIncrement(name, nameMap.map(({name}) => name )))
+        .map(name => uniqueByIncrement(name, nameMap.map(({ name }) => name)))
         .pop()
       break
 
   }
 
-  nameMap.push({id, name})
+  nameMap.push({ id, name })
   return name
 }
 
-function pascalCase (name: string) {
+function pascalCase(name: string) {
   return name
     .split(/\s+/g)
     .filter(_ => _ !== '')
@@ -114,7 +117,7 @@ function capitalize(name: string) {
   return name.charAt(0).toUpperCase() + name.slice(1)
 }
 
-function normalizeInvalidTypeName (name: string): string {
+function normalizeInvalidTypeName(name: string): string {
   if (/^[a-zA-Z][a-zA-Z0-9]*$/.test(name)) {
     return name
   } else {
@@ -126,7 +129,7 @@ function normalizeInvalidTypeName (name: string): string {
   }
 }
 
-function uniqueByIncrement (name: string, names: string[]): string {
+function uniqueByIncrement(name: string, names: string[]): string {
   for (let i = 0; i < 1000; i++) {
     const nameProposal = i === 0 ? name : `${name}${i + 1}`
     if (!names.includes(nameProposal)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ shim()
 
 export default function JsonToTS(json: any, userOptions?: Options): string[] {
   const defaultOptions: Options = {
-    rootName: 'RootObject'
+    rootName: 'RootObject',
+    prefix: ''
   }
   const options = {
     ...defaultOptions,
@@ -38,7 +39,7 @@ export default function JsonToTS(json: any, userOptions?: Options): string[] {
    */
   optimizeTypeStructure(typeStructure)
 
-  const names = getNames(typeStructure, options.rootName)
+  const names = getNames(typeStructure, options.rootName, options.prefix)
 
   return getInterfaceDescriptions(typeStructure, names)
     .map(getInterfaceStringFromDescription)

--- a/src/model.ts
+++ b/src/model.ts
@@ -5,7 +5,7 @@ export enum TypeGroup {
 export interface TypeDescription {
   id: string
   isUnion?: boolean
-  typeObj?: {[index: string]: string}
+  typeObj?: { [index: string]: string }
   arrayOfTypes?: string[]
 }
 
@@ -30,7 +30,8 @@ export interface InterfaceDescription {
 }
 
 export interface Options {
-  rootName: string
+  rootName: string,
+  prefix: string
 }
 
 export interface KeyMetaData {


### PR DESCRIPTION
I really appreciate that this json-to-ts converter properly dealt with nested Arrays and allowed me to rename the RootObject. But often, I want to prefix everything like SomeDescriptionRootObject, and also prefix any named interface that is a part of that type. i.e.

```typescript
JsonToTs(json,{rootName:"RootObject", prefix: "NamedPrefix"})
```
produces:
```typescript
interface NamedPrefixRootObject {
  current_page: number;
  total_pages: number;
  models: NamedPrefixModel[];
}
interface NamedPrefixModel {
  id: number;
  quantity: number;
  price: number;
  taker_side: string;
  created_at: number;
}
```