### PR TITLE
feat: add support for `jsdoc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,43 @@ interface Cat {
 }
 ```
 
+### JSDoc
+Note: use special char(#@! and white-space) as property key will be ignored by vscode
+
+```javascript
+const JsonToTS = require('json-to-ts', {
+  isUseJSDoc: true
+})
+
+const json = {
+  cats: [
+    {name: 'Kittin'},
+    {name: 'Mittin'}
+  ],
+  favoriteNumber: 42,
+  favoriteWord: 'Hello'
+}
+
+JsonToTS(json).forEach( typeInterface => {
+  console.log(typeInterface)
+})
+```
+
+#### Output:
+
+```typescript
+/** 
+ * @typedef {object} RootObject
+ * @property {Cat[]} cats
+ * @property {number} favoriteNumber
+ * @property {string} favoriteWord
+ */
+/**
+ * @typedef {object} Cat
+ * @property {string} name
+ */
+```
+
 ## Converter
 - Array type merging (**Big deal**)
 - Union types

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublish": "npm run build",
     "build": "rm -rf ./build && tsc",
     "start": "nodemon -e ts -w src -x 'ts-node src/index.ts'",
-    "test": "npm run build && mocha ./test/js-integration/index.js && mocha ./build/test",
+    "test": "npm run build && mocha ./test/js-integration/index.js && mocha ./build/test && mocha ./build/test/jsdoc",
     "test-reload": "nodemon -e ts -w test -w src -x 'npm test'"
   },
   "author": "https://github.com/mariusalch",

--- a/src/get-interfaces.ts
+++ b/src/get-interfaces.ts
@@ -93,6 +93,25 @@ export function getInterfaceStringFromDescription({ name, typeMap }: InterfaceDe
   return interfaceString;
 }
 
+function getJSDocOptionalKeyString(key: string) {
+  const roption = /\?$/
+  return roption.test(key) ? `[${key.replace(roption, '')}]` : key
+}
+
+export function getJSDocStringFromDescription({ name, typeMap }: InterfaceDescription): string {
+  const stringTypeMap = Object.entries(typeMap)
+    .map(([key, name]) => {
+      return ` * @property {${name}} ${getJSDocOptionalKeyString(key)}\n`
+    })
+    .reduce((a, b) => (a += b), "");
+
+  let interfaceString = `/**\n * @typedef {object} ${name} \n`;
+  interfaceString += stringTypeMap;
+  interfaceString += " */";
+
+  return interfaceString;
+}
+
 export function getInterfaceDescriptions(typeStructure: TypeStructure, names: NameEntry[]): InterfaceDescription[] {
   return names
     .map(({ id, name }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import { Options } from "./model";
 import { shim } from "es7-shim/es7-shim";
 import {
   getInterfaceDescriptions,
-  getInterfaceStringFromDescription
+  getInterfaceStringFromDescription,
+  getJSDocStringFromDescription
 } from "./get-interfaces";
 import { getNames } from "./get-names";
 import { isArray, isObject } from "./util";
@@ -41,7 +42,7 @@ export default function JsonToTS(json: any, userOptions?: Options): string[] {
   const names = getNames(typeStructure, options.rootName);
 
   return getInterfaceDescriptions(typeStructure, names).map(
-    getInterfaceStringFromDescription
+    options.isUseJSDoc ? getJSDocStringFromDescription : getInterfaceStringFromDescription
   );
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -33,7 +33,8 @@ export interface InterfaceDescription {
 }
 
 export interface Options {
-  rootName: string;
+  rootName?: string;
+  isUseJSDoc?: boolean;
 }
 
 export interface KeyMetaData {

--- a/test/jsdoc/array-merging.spec.ts
+++ b/test/jsdoc/array-merging.spec.ts
@@ -1,0 +1,470 @@
+import * as assert from "assert";
+import { removeWhiteSpace, JsonToJSDoc } from "../util/index";
+
+describe("[JSDoc] Array type merging", function() {
+  it("should work with arrays with same inner types", function() {
+    const json = {
+      cats: [{ name: "Kittin" }, { name: "Sparkles" }]
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {Cat[]} cats
+        */
+      `,
+      `/**
+        * @typedef {object} Cat
+        * @property {string} name
+        */
+      `
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 2);
+  });
+
+  it("union null type should be emited and field should be marked as optional", function() {
+    const json = [{ age: 42 }, { age: null }];
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject 
+        * @property {number} [age]
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 1);
+  });
+
+  it("null should stay if it is part of array elements", function() {
+    const json = {
+      arr: [42, "42", null]
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {(null | number | string)[]} arr
+        */
+      `
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 1);
+  });
+
+  it("array types should be merge even if they are nullable", function() {
+    const json = [
+      {
+        field: ["string"]
+      },
+      {
+        field: [42]
+      },
+      {
+        field: null
+      },
+      {
+        field: [new Date()]
+      }
+    ];
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {(Date | number | string )[]} [field]
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 1);
+  });
+
+  it("object types should be merge even if they are nullable", function() {
+    const json = [
+      {
+        field: { tag: "world" }
+      },
+      {
+        field: { tag: 42 }
+      },
+      {
+        field: null
+      }
+    ];
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {Field} [field]
+        */`,
+      `/**
+        * @typedef {object} Field
+        * @property {number | string} tag
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 2);
+  });
+
+  it("should work with arrays with inner types that has optinal field", function() {
+    const json = {
+      cats: [{ name: "Kittin" }, { name: "Sparkles", age: 20 }]
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {Cat[]} cats
+        */`,
+      `/**
+        * @typedef {object} Cat
+        * @property {string} name
+        * @property {number} [age]
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 2);
+  });
+
+  it("should work with arrays with inner types that has no common fields", function() {
+    const json = {
+      cats: [{ name: "Kittin" }, { age: 20 }]
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject 
+        * @property {Cat[]} cats
+        */`,
+      `/**
+        * @typedef {object} Cat 
+        * @property {string} [name]
+        * @property {number} [age]
+        */
+      `
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 2);
+  });
+
+  it("should work with arrays with inner types that have common field that has different types", function() {
+    const json = {
+      cats: [{ age: "20" }, { age: 20 }]
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {Cat[]} cats
+        */`,
+      `/**
+        * @typedef {object} Cat
+        * @property {number | string} age
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 2);
+  });
+
+  it("should solve edge case 1", function() {
+    const json = {
+      cats: [{ age: [42] }, { age: ["42"] }],
+      dads: ["hello", 42]
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property { Cat[]} cats
+        * @property {(number | string)[]} dads
+        */`,
+      `/**
+        * @typedef {object} Cat
+        * @property {(number | string)[]} age 
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 2);
+  });
+
+  it("should solve edge case 2", function() {
+    const json = {
+      items: [
+        {
+          billables: [
+            {
+              quantity: 2,
+              price: 0
+            }
+          ]
+        },
+        {
+          billables: [
+            {
+              priceCategory: {
+                title: "Adult",
+                minAge: 0,
+                maxAge: 99
+              },
+              quantity: 2,
+              price: 226
+            }
+          ]
+        }
+      ]
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {Item[]} items
+        */`,
+      `/**
+        * @typedef {object} Item 
+        * @property {Billable[]} billables
+        */`,
+      `/**
+        * @typedef {object} Billable 
+        * @property {number} quantity
+        * @property {number} price
+        * @property {PriceCategory} [priceCategory]
+        */`,
+      `/**
+        * @typedef {object} PriceCategory 
+        * @property {string} title
+        * @property {number} minAge
+        * @property {number} maxAge
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 4);
+  });
+
+  it("should solve edge case 3", function() {
+    const json = [
+      {
+        nestedElements: [
+          {
+            commonField: 42,
+            optionalField: "field"
+          },
+          {
+            commonField: 42,
+            optionalField3: "field3"
+          }
+        ]
+      },
+      {
+        nestedElements: [
+          {
+            commonField: "42",
+            optionalField2: "field2"
+          }
+        ]
+      }
+    ];
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {NestedElement[]} nestedElements
+        */`,
+      `/**
+        * @typedef {object} NestedElement
+        * @property {number | string} commonField
+        * @property {string} [optionalField]
+        * @property {string} [optionalField3]
+        * @property {string} [optionalField2]
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 2);
+  });
+
+  it("should merge empty array with primitive types", function() {
+    const json = [
+      {
+        nestedElements: []
+      },
+      {
+        nestedElements: ["kittin"]
+      }
+    ];
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {string[]} nestedElements
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 1);
+  });
+
+  it("should merge empty array with object types", function() {
+    const json = [
+      {
+        nestedElements: []
+      },
+      {
+        nestedElements: [{ name: "kittin" }]
+      }
+    ];
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {NestedElement[]} nestedElements
+        */`,
+      `/**
+        * @typedef {object} NestedElement
+        * @property {string} name
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 2);
+  });
+
+  it("should merge empty array with array types", function() {
+    const json = [
+      {
+        nestedElements: []
+      },
+      {
+        nestedElements: [["string"]]
+      }
+    ];
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {string[][]} nestedElements
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 1);
+  });
+
+  it("should merge union types with readable names ", function() {
+    const json = [
+      {
+        marius: "marius"
+      },
+      {
+        marius: [42]
+      }
+    ];
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property  {number[] | string} marius
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert.strictEqual(interfaces.length, 1);
+  });
+});

--- a/test/jsdoc/multiple-interface.spec.ts
+++ b/test/jsdoc/multiple-interface.spec.ts
@@ -1,0 +1,235 @@
+import * as assert from "assert";
+import { removeWhiteSpace, JsonToJSDoc } from "../util/index";
+
+// special chars as property are ignored by typescript
+// so these cases are also removed
+
+describe("[JSDoc] Multiple interfaces", function() {
+  it("should create separate interface for nested objects", function() {
+    const json = {
+      a: {
+        b: 42
+      }
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {A} a
+        */`,
+      `/**
+        * @typedef {object} A
+        * @property {number} b
+        */`
+    ].map(removeWhiteSpace);
+
+    JsonToJSDoc(json).forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+  });
+
+  it("should not create duplicate on same type object fields", function() {
+    const json = {
+      a: {
+        b: 42
+      },
+      c: {
+        b: 24
+      }
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {A} a
+        * @property {A} c
+        */`,
+      `/**
+        * @typedef {object} A 
+        * @property {number} b
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+
+    assert(interfaces.length === 2);
+  });
+
+  it("should have unique names for nested objects since they ", function() {
+    const json = {
+      name: "Larry",
+      parent: {
+        name: "Garry",
+        parent: {
+          name: "Marry",
+          parent: null
+        }
+      }
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {string} name
+        * @property {Parent2} parent
+        */`,
+      `/**
+        * @typedef {object} Parent
+        * @property {string} name
+        * @property {any} [parent]
+        */`,
+      `/**
+        * @typedef {object} Parent2
+        * @property {string} name
+        * @property {Parent} parent
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+  });
+
+  it("should support multi nested arrays", function() {
+    const json = {
+      cats: [
+        [{ name: "Kittin" }, { name: "Kittin" }, { name: "Kittin" }],
+        [{ name: "Kittin" }, { name: "Kittin" }, { name: "Kittin" }]
+      ]
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {Cat[][]} cats
+        */`,
+      `/**
+        * @typedef {object} Cat
+        * @property {string} name
+        */`
+    ].map(removeWhiteSpace);
+
+    JsonToJSDoc(json).forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+  });
+
+  it("should singularize array types (dogs: [...] => dogs: Dog[] )", function() {
+    const json = {
+      dogs: [{ name: "sparky" }, { name: "goodboi" }]
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {Dog[]} dogs
+        */`,
+      `/**
+        * @typedef {object} Dog
+        * @property {string} name
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+  });
+
+  it("should not singularize if not array type (dogs: {} => dogs: Dogs )", function() {
+    const json = {
+      cats: {
+        popularity: "very popular"
+      }
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {Cats} cats
+        */`,
+      `/**
+        * @typedef {object} Cats
+        * @property {string} popularity
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+  });
+
+  it("should capitalize interface names", function() {
+    const json = {
+      cat: {}
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject 
+        * @property {Cat} cat
+        */`,
+      `/**
+        * @typedef {object} Cat
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+  });
+
+  it("should start unique names increment with 2", function() {
+    const json = {
+      a: {
+        human: { legs: 4 }
+      },
+      b: {
+        human: { arms: 2 }
+      }
+    };
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {A} a
+        * @property {B} b
+        */`,
+      `/**
+        * @typedef {object} A
+        * @property {Human} human
+        */`,
+      `/**
+        * @typedef {object} B
+        * @property {Human2} human
+        */`,
+      `/**
+        * @typedef {object} Human
+        * @property {number} legs
+        */`,
+      `/**
+        * @typedef {object} Human2
+        * @property {number} arms
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+  });
+});

--- a/test/jsdoc/root-array.spec.ts
+++ b/test/jsdoc/root-array.spec.ts
@@ -1,0 +1,86 @@
+import * as assert from "assert";
+import { removeWhiteSpace, JsonToJSDoc } from "../util/index";
+
+describe("[JSDoc] Root array type", function() {
+  it("should throw error on unsupprted array types", function() {
+    const unsupportedArrays = [
+      ["sample string", "sample string2"],
+      [42, 32],
+      [true, false],
+      [null, null],
+      [42, "sample string"],
+      [42, { marius: "marius" }],
+      []
+    ];
+
+    const expectedMessage = "Only (Object) and (Array of Object) are supported";
+
+    unsupportedArrays.forEach(arr => {
+      try {
+        JsonToJSDoc(arr);
+        assert(false, "error should be thrown");
+      } catch (e) {
+        assert.strictEqual(e.message, expectedMessage);
+        if (e.message !== expectedMessage) throw e;
+      }
+    });
+  });
+
+  it("should handle array with single object [object]", function() {
+    const json = [{ marius: "marius" }];
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {string} marius
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+    assert.equal(interfaces.length, 1);
+  });
+
+  it("should handle array with multiple same objects [object, object]", function() {
+    const json = [{ marius: "marius" }, { marius: "marius" }];
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {string} marius
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+    assert.equal(interfaces.length, 1);
+  });
+
+  it("should handle array with multiple different objects [object1, object2]", function() {
+    const json = [{ marius: "marius" }, { darius: "darius" }];
+
+    const expectedTypes = [
+      `/**
+        * @typedef {object} RootObject
+        * @property {string} [marius]
+        * @property {string} [darius]
+        */`
+    ].map(removeWhiteSpace);
+
+    const interfaces = JsonToJSDoc(json);
+
+    interfaces.forEach(i => {
+      const noWhiteSpaceInterface = removeWhiteSpace(i);
+      assert(expectedTypes.includes(noWhiteSpaceInterface));
+    });
+    assert.equal(interfaces.length, 1);
+  });
+});

--- a/test/jsdoc/single-interface.spec.ts
+++ b/test/jsdoc/single-interface.spec.ts
@@ -1,0 +1,137 @@
+import * as assert from "assert";
+import { removeWhiteSpace, JsonToJSDoc } from "../util/index";
+
+// seem jsdoc of vscode not support property with space, like `hello world`
+// so it was removed from the test case
+
+describe("[JSDoc] Single interface", function () {
+  it("should work with empty objects", function () {
+    const json = {};
+
+    const expected = `
+      /**
+       * @typedef {object} RootObject 
+       */
+    `;
+    const actual = JsonToJSDoc(json).pop();
+    const [a, b] = [expected, actual].map(removeWhiteSpace);
+    assert.strictEqual(a, b);
+  });
+
+  it("should not quote underscore key names", function () {
+    const json = {
+      _marius: "marius",
+    };
+
+    const expected = `
+      /**
+       * @typedef {object} RootObject
+       * @property {string} _marius
+       */
+    `;
+    const actual = JsonToJSDoc(json).pop();
+    const [a, b] = [expected, actual].map(removeWhiteSpace);
+    assert.strictEqual(a, b);
+  });
+
+  it("should convert Date to Date type", function () {
+    const json = {
+      _marius: new Date(),
+    };
+
+    const expected = `
+      /**
+       * @typedef {object} RootObject
+       * @property {Date} _marius
+       */
+    `;
+    const actual = JsonToJSDoc(json).pop();
+    const [a, b] = [expected, actual].map(removeWhiteSpace);
+    assert.strictEqual(a, b);
+  });
+
+  it("should work with primitive types", function () {
+    const json = {
+      str: "this is string",
+      num: 42,
+      bool: true,
+    };
+
+    const expected = `
+      /** 
+       * @typedef {object} RootObject
+       * @property {string} str
+       * @property {number} num
+       * @property {boolean} bool
+       */
+    `;
+    const interfaceStr = JsonToJSDoc(json).pop();
+    const [expect, actual] = [expected, interfaceStr].map(removeWhiteSpace);
+    assert.strictEqual(expect, actual);
+  });
+
+  it("should keep field order", function () {
+    const json = {
+      c: "this is string",
+      a: 42,
+      b: true,
+    };
+
+    const expected = `
+      /**
+       * @typedef {object} RootObject
+       * @property {string} c
+       * @property {number} a
+       * @property {boolean} b
+       */
+    `;
+    const interfaceStr = JsonToJSDoc(json).pop();
+    const [expect, actual] = [expected, interfaceStr].map(removeWhiteSpace);
+    assert.strictEqual(expect, actual);
+  });
+
+  it("should add optional field modifier on null values", function () {
+    const json = {
+      field: null,
+    };
+
+    const expected = `
+      /**
+       * @typedef {object} RootObject
+       * @property {any} [field]
+       */
+    `;
+    const actual = JsonToJSDoc(json).pop();
+    const [a, b] = [expected, actual].map(removeWhiteSpace);
+    assert.strictEqual(a, b);
+  });
+
+  it('should name root object interface "RootObject"', function () {
+    const json = {};
+
+    const expected = `
+      /**
+       * @typedef {object} RootObject
+       */
+    `;
+    const actual = JsonToJSDoc(json).pop();
+    const [a, b] = [expected, actual].map(removeWhiteSpace);
+    assert.strictEqual(a, b);
+  });
+
+  it("should empty array should be any[]", function () {
+    const json = {
+      arr: [],
+    };
+
+    const expected = `
+      /**
+       * @typedef {object} RootObject
+       * @property {any[]} arr
+       */
+    `;
+    const actual = JsonToJSDoc(json).pop();
+    const [a, b] = [expected, actual].map(removeWhiteSpace);
+    assert.strictEqual(a, b);
+  });
+});

--- a/test/util/index.ts
+++ b/test/util/index.ts
@@ -1,1 +1,8 @@
+import  JsonToTS from "../../src/index";
 export const removeWhiteSpace = str => str.replace(/\s/g, '')
+
+export const JsonToJSDoc = (json) => {
+  return JsonToTS(json, {
+    isUseJSDoc: true
+  })
+}


### PR DESCRIPTION
I didn't add the test cases of that which use '#@#123#@#' or 'hello world' as property key. The keys seem not valid on typescript and i didn't find the way to fix it.