### PR TITLE
fix for the error - Reduce of empty array with no initial value

### DIFF
--- a/src/get-names.ts
+++ b/src/get-names.ts
@@ -101,7 +101,7 @@ function pascalCase(name: string) {
     .split(/\s+/g)
     .filter(_ => _ !== "")
     .map(capitalize)
-    .reduce((a, b) => a + b);
+    .reduce((a, b) => a + b, "");
 }
 
 function capitalize(name: string) {


### PR DESCRIPTION
Hi,

When a JSON has empty key string, this error occurs as the `reduce` call in the [pascelCase function](https://github.com/MariusAlch/json-to-ts/blob/83d3ae9d9c03e13d60479fd5e7c4313d303a3a3b/src/get-names.ts#L104) of getNames module doesn't have a default value.

```json
{
  "a": {
    "": {
      "": ""
    }
  }
}
```

The above JSON will throw the error.

Fixes #18.